### PR TITLE
fix: Child Rect Measurement Bug in React Native 0.77

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -273,7 +273,7 @@ class Tooltip extends Component {
         this.isMeasuringChild = true;
         if (
           this.childWrapper.current &&
-          typeof this.childWrapper.current.measure === 'function'
+          typeof this.childWrapper.current.measureInWindow === 'function'
         ) {
           this.childWrapper.current.measureInWindow((x, y, width, height) => {
             const childRect = new Rect(x, y, width, height);

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -275,24 +275,16 @@ class Tooltip extends Component {
           this.childWrapper.current &&
           typeof this.childWrapper.current.measure === 'function'
         ) {
-          
-          this.childWrapper.current.measure(
-            (x, y, width, height, pageX, pageY) => {
-              const extraHeight = this.props.imageResource ? y : 0;
-
-  
-              const operator = this.props.placement !== "bottom" ? -1 : 1;
-              const childRect = new Rect(pageX, pageY + (extraHeight * operator) , width, height);
-              
-              if (
-                Object.values(childRect).every(value => value !== undefined)
-              ) {
-                this.onChildMeasurementComplete(childRect);
-              } else {
-                this.doChildlessPlacement();
-              }
-            },
-          );
+          this.childWrapper.current.measureInWindow((x, y, width, height) => {
+            const childRect = new Rect(x, y, width, height);
+            if (
+              Object.values(childRect).every((value) => value !== undefined)
+            ) {
+              this.onChildMeasurementComplete(childRect);
+            } else {
+              this.doChildlessPlacement();
+            }
+          });
         } else {
           this.doChildlessPlacement();
         }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -209,7 +209,7 @@ class Tooltip extends Component {
     return null;
   }
 
-  updateWindowDims = dims => {
+  updateWindowDims = (dims) => {
     this.setState(
       {
         windowDims: dims.window,
@@ -238,7 +238,7 @@ class Tooltip extends Component {
     );
   };
 
-  measureContent = e => {
+  measureContent = (e) => {
     const { width, height } = e.nativeEvent.layout;
     const contentSize = new Size(width, height);
     this.setState({ contentSize }, () => {
@@ -246,13 +246,13 @@ class Tooltip extends Component {
     });
   };
 
-  measureImageResource = e => {
+  measureImageResource = (e) => {
     const { width, height } = e.nativeEvent.layout;
 
-    alert(height)
-  }
+    alert(height);
+  };
 
-  onChildMeasurementComplete = rect => {
+  onChildMeasurementComplete = (rect) => {
     this.setState(
       {
         childRect: rect,
@@ -273,18 +273,28 @@ class Tooltip extends Component {
         this.isMeasuringChild = true;
         if (
           this.childWrapper.current &&
-          typeof this.childWrapper.current.measureInWindow === 'function'
+          typeof this.childWrapper.current.measure === 'function'
         ) {
-          this.childWrapper.current.measureInWindow((x, y, width, height) => {
-            const childRect = new Rect(x, y, width, height);
-            if (
-              Object.values(childRect).every((value) => value !== undefined)
-            ) {
-              this.onChildMeasurementComplete(childRect);
-            } else {
-              this.doChildlessPlacement();
-            }
-          });
+          this.childWrapper.current.measure(
+            (x, y, width, height, pageX, pageY) => {
+              const extraHeight = this.props.imageResource ? y : 0;
+              const operator = this.props.placement !== 'bottom' ? -1 : 1;
+              const childRect = new Rect(
+                pageX,
+                pageY + extraHeight * operator,
+                width,
+                height,
+              );
+
+              if (
+                Object.values(childRect).every((value) => value !== undefined)
+              ) {
+                this.onChildMeasurementComplete(childRect);
+              } else {
+                this.doChildlessPlacement();
+              }
+            },
+          );
         } else {
           this.doChildlessPlacement();
         }
@@ -305,13 +315,8 @@ class Tooltip extends Component {
 
   computeGeometry = () => {
     const { arrowSize, childContentSpacing } = this.props;
-    const {
-      childRect,
-      contentSize,
-      displayInsets,
-      placement,
-      windowDims,
-    } = this.state;
+    const { childRect, contentSize, displayInsets, placement, windowDims } =
+      this.state;
 
     const options = {
       displayInsets,
@@ -390,19 +395,21 @@ class Tooltip extends Component {
             this.props.childrenWrapperStyle,
           ]}
         >
-          {
-              this.props.imageResource
-              ? <ImageBackground source={this.props.imageResource} resizeMode="contain" style={this.props.toolTipBackgroundStyle}>
-                {
-                  (!this.props.hideChild)
-                  && <Wrapper style={this.props.childStyle}>
-                      {this.props.children}
-                    </Wrapper> 
-                }
+          {this.props.imageResource ? (
+            <ImageBackground
+              source={this.props.imageResource}
+              resizeMode="contain"
+              style={this.props.toolTipBackgroundStyle}
+            >
+              {!this.props.hideChild && (
+                <Wrapper style={this.props.childStyle}>
+                  {this.props.children}
+                </Wrapper>
+              )}
             </ImageBackground>
-            : this.props.children
-          }
-            
+          ) : (
+            this.props.children
+          )}
         </View>
       </TooltipChildrenContext.Provider>
     );
@@ -460,7 +467,8 @@ class Tooltip extends Component {
   };
 
   render() {
-    const { children, isVisible, useReactNativeModal, modalComponent } = this.props;
+    const { children, isVisible, useReactNativeModal, modalComponent } =
+      this.props;
 
     const hasChildren = React.Children.count(children) > 0;
     const showTooltip = isVisible && !this.state.waitingForInteractions;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -473,6 +473,7 @@ class Tooltip extends Component {
             transparent
             visible={showTooltip}
             onRequestClose={this.props.onClose}
+            statusBarTranslucent
             supportedOrientations={this.props.supportedOrientations}
           >
             {this.renderContentForTooltip()}


### PR DESCRIPTION
## 🧠 Summary

This pull request addresses a bug related to measuring the child component's rectangle in React Native version 0.77. The issue was caused by the use of the `measure` method, which has been updated to `measureInWindow` to ensure accurate measurements of the child component's dimensions and position.

## ✅ Changes

- Replaced the `measure` method with `measureInWindow` in the `Tooltip` component.
- Simplified the logic for calculating the `childRect` by removing unnecessary calculations and conditions.
- Ensured that the `childRect` is only processed if all its values are defined, otherwise, it defaults to a childless placement.

## 📈 Impact

This change ensures that the tooltip accurately positions itself relative to the child component, fixing layout issues that were occurring in React Native 0.77.

